### PR TITLE
Disable ufw rules in pyslackers.nginx for Travis

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,6 +10,7 @@
     rpc_port: 8080
 
     # pyslackers.nginx variables
+    ufw_enabled: False  # UFW is not installed in test images
     nginx_sites:
       transmission:
         locations:


### PR DESCRIPTION
UFW is not installed in test images